### PR TITLE
Enable environment variables

### DIFF
--- a/src/fetch-block.go
+++ b/src/fetch-block.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"os"
 	"strconv"
+	"strings"
 	"time"
 
 	"sync"
@@ -398,6 +399,9 @@ func main() {
 	viper.SetConfigType("yaml")
 	viper.SetConfigName("config")
 	viper.AddConfigPath(".")
+	viper.SetEnvPrefix("FB")
+	viper.AutomaticEnv()
+	viper.SetEnvKeyReplacer(strings.NewReplacer("-", "_", ".", "_"))
 	if err := viper.ReadInConfig(); err != nil {
 		fmt.Printf("Fatol error when read config file: err %s\n", err)
 	}


### PR DESCRIPTION
Let's also enable environment variables to allow us more flexible control via docker-compose.

Signed-off-by: Tatsushi Inagaki <e29253@jp.ibm.com>