### PR TITLE
Add parameters to control log outputs

### DIFF
--- a/src/config.yaml
+++ b/src/config.yaml
@@ -22,4 +22,7 @@ tls:
     rootcert:        
         file: /full/path/to/crypto-config/peerOrganizations/org0.example.com/users/Admin@org0.example.com/tls/ca.crt
     serverhostoverride: peer0       
-
+log:
+    event: true
+    block: true
+    blockperf: true


### PR DESCRIPTION
Let's add new parameters so that we can selectively generate logs to save the disk usage. I added three new parameters to control log outputs for:
- Event notification
- Contents of a block
- Latency of each transaction

Signed-off-by: Tatsushi Inagaki <e29253@jp.ibm.com>